### PR TITLE
fix: strip ANSI codes calculating cell width

### DIFF
--- a/boxed.go
+++ b/boxed.go
@@ -53,8 +53,9 @@ func (bx *Boxed) addRow(dst *[]Row, row Row) error {
 
 	for i, col := range row.cells {
 		v := fmt.Sprintf("%v", col)
-		if bx.cellWidth[i] < len(v) {
-			bx.cellWidth[i] = len(v)
+		l := len(StripNoneGraphic(v))
+		if bx.cellWidth[i] < l {
+			bx.cellWidth[i] = l
 		}
 	}
 	*dst = append(*dst, row)
@@ -173,7 +174,8 @@ func (bx *Boxed) row(w io.Writer, row Row, header bool) error {
 			Fprint(w, " ")
 		}
 
-		content := fmt.Sprintf("%-*v", bx.cellWidth[j], col)
+		v := fmt.Sprintf("%v", col)
+		content := v + strings.Repeat(" ", bx.cellWidth[j]-len(StripNoneGraphic(v)))
 		Fprint(w, content)
 
 		if j == len(row.cells)-1 {
@@ -240,7 +242,6 @@ func (bx *Boxed) render(w io.Writer) error {
 // Render will print the result to STDOUT. Use RenderTo to write to an io.Writer,
 // or RenderAsString to get the string.
 func (bx *Boxed) Render() error {
-
 	return bx.render(os.Stdout)
 }
 

--- a/boxed_test.go
+++ b/boxed_test.go
@@ -3,6 +3,7 @@
 package boxed
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/golistic/xgo/xt"
@@ -26,6 +27,68 @@ func TestBoxed_AddRows(t *testing.T) {
 		}...))
 
 		xt.Eq(t, exp, "\n"+box.RenderAsString()) // extra newline for pretty output
+	})
+
+	t.Run("with ANSI codes (1)", func(t *testing.T) {
+
+		exp := strings.Join([]string{
+			"",
+			"┌────┬───────────────────────────────────────────────┬────┐",
+			"│ \u001B[32m1A\u001B[0m │ 1B                                            │ 1C │",
+			"│ 2A │ \u001B[1mThe world's most popular open source database\u001B[0m │ 2C │",
+			"└────┴───────────────────────────────────────────────┴────┘",
+			"",
+		}, "\n")
+
+		box := New()
+		xt.OK(t, box.Append([]Row{
+			NewRow("\u001B[32m1A\u001B[0m", "1B", "1C"),
+			NewRow("2A", "\033[1mThe world's most popular open source database\033[0m", "2C"),
+		}...))
+
+		xt.Eq(t, exp, "\n"+box.RenderAsString()) // extra newline for pretty output
+	})
+
+	t.Run("with ANSI codes (2)", func(t *testing.T) {
+
+		exp := strings.Join([]string{
+			"",
+			"┌────┬───────────────────────────────────────────────┐",
+			"│ 2A │ \u001B[1mThe world's most popular open source database\u001B[0m │",
+			"│ \u001B[32m1A\u001B[0m │ 1B                                            │",
+			"└────┴───────────────────────────────────────────────┘",
+			"",
+		}, "\n")
+
+		box := New()
+		xt.OK(t, box.Append([]Row{
+			NewRow("2A", "\033[1mThe world's most popular open source database\u001B[0m"),
+			NewRow("\u001B[32m1A\u001B[0m", "1B"),
+		}...))
+
+		xt.Eq(t, exp, "\n"+box.RenderAsString()) // extra newline for pretty output
+	})
+
+	t.Run("with ANSI codes (3)", func(t *testing.T) {
+
+		exp := strings.Join([]string{
+			"",
+			"┌────┬───────────────────────────────────────────────┐",
+			"│ \u001B[2J2A │ \u001B[1mThe world's most popular open source database\u001B[0m │",
+			"│ 1A │ \u001B[32m1B\u001B[0m                                            │",
+			"└────┴───────────────────────────────────────────────┘",
+			"",
+		}, "\n")
+
+		box := New()
+		xt.OK(t, box.Append([]Row{
+			NewRow("\033[2J2A", "\033[1mThe world's most popular open source database\u001B[0m"),
+			NewRow("1A", "\u001B[32m1B\u001B[0m"),
+		}...))
+
+		have := "\n" + box.RenderAsString() // extra newline for pretty output
+
+		xt.Eq(t, exp, have)
 	})
 }
 

--- a/strings.go
+++ b/strings.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package boxed
+
+import (
+	"strings"
+	"unicode"
+)
+
+// StripNoneGraphic removes any CSI ANSI escape code sequences and
+// non-Graphic runes from the s.
+//
+// CSI, Control Sequence Introducer, are completely removed.
+// OSC, Operating System Command, (or anything else) are not removed, but since we
+// remove the escape code, the characters will be part of the resulting
+// string.
+//
+// This function is not meant to cleanse malicious codes in strings. It is meant
+// to be used to calculate string lengths within the boxed-package.
+func StripNoneGraphic(s string) string {
+
+	var stripped strings.Builder
+	inCode := false
+
+	sl := len(s)
+	runes := []rune(s)
+
+	for i := 0; i < sl; i++ {
+		r := runes[i]
+
+		switch {
+		case r == 0x1b: // or 27 or \033 or \u001b
+			if sl-1 != i && (s[i+1] == '[') {
+				inCode = true
+				i++
+			}
+			// ignore the escape
+		case inCode && (r >= 0x40 && r <= 0x7e):
+			inCode = false
+		case !inCode:
+			if unicode.IsGraphic(r) {
+				stripped.WriteRune(r)
+			}
+		}
+	}
+
+	return stripped.String()
+}

--- a/strings_test.go
+++ b/strings_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Geert JM Vanderkelen
+ */
+
+package boxed
+
+import (
+	"testing"
+
+	"github.com/golistic/xgo/xt"
+)
+
+func TestStripNoneGraphic(t *testing.T) {
+	t.Run("strip text formatting", func(t *testing.T) {
+		var cases = []struct {
+			got string
+			exp string
+		}{
+			{
+				got: "\033[1mbold\033[0m",
+				exp: "bold",
+			},
+			{
+				got: "\033[2Jclearing screen",
+				exp: "clearing screen",
+			},
+			{
+				got: "\033[no code",
+				exp: "o code", // corrupts the string, but that's how it works
+			},
+			{
+				got: "\033rogue escape",
+				exp: "rogue escape",
+			},
+			{
+				got: "\033]0;Window title change\a",
+				exp: "]0;Window title change",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.exp, func(t *testing.T) {
+				xt.Eq(t, c.exp, StripNoneGraphic(c.got))
+			})
+		}
+	})
+}


### PR DESCRIPTION
We strip ANSI codes when calculating width of cells  making sure that the columns are aligned correctly.